### PR TITLE
Set zip_safe to False

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
         author = "Qingnan Zhou",
         author_email = "qnzhou@gmail.com",
         license = "MPL",
+        zip_safe = False,
         package_dir = {"": "python"},
         packages = ["pymesh", "pymesh.misc", "pymesh.meshutils", "pymesh.wires",
             "pymesh.tests", "pymesh.meshutils.tests", "pymesh.wires.tests"],


### PR DESCRIPTION
I was not able to install PyMesh into my virtualenv. `python setup.py install` worked, but afterwards I ran into import errors, I think because the C modules could not be found. This change fixes the issue for me.

This should enable easier non-root installs of PyMesh, which is desirable. Running `python setup.py install`, `pip install` or equivalent commands as root is bad and can break systems (especially Linux) in horrible ways.

For reference, I am currently using the script below to install PyMesh on Debian. Maybe we could write a small installer based on this.

```bash
#!/bin/bash
set -xe

sudo apt-get update
sudo apt-get install -y \
    python3-pip \
    python3-tk \
    python3-dev \
    git \
    cmake \
    libgmp3-dev \
    libmpfr-dev \
    libmpfr-doc \
    libmpfr4 \
    libmpfr4-dbg \
    libboost-all-dev \
    libcgal-dev \
    libpython-dev \
    swig

# TODO: Pin these to exact versions.
pip3 install \
    setuptools \
    numpy \
    scipy \
    trimesh \
    matplotlib \
    pytest \
    pybind11

# Get data from Git
cd ~
git clone https://github.com/qnzhou/PyMesh.git
cd PyMesh
git checkout ${PYMESH_COMMIT}
git submodule update --init

# Build third party libaries
cd ~/PyMesh/third_party
mkdir build
cd build
cmake ..
make
make install

# Build PyMesh
cd ~/PyMesh/
mkdir build
cd build
cmake ..
make
make all_tests

# Install PyMesh
cd ~/PyMesh/
python3 ./setup.py build
python3 ./setup.py install



```