### PR TITLE
Small typo in docs

### DIFF
--- a/docs/api_mesh_generation.rst
+++ b/docs/api_mesh_generation.rst
@@ -4,7 +4,7 @@ Mesh Generation
 Triangulation
 -------------
 
-Triangulation is 2D is often solved using Shewchuk's `triangle library
+Triangulation in 2D is often solved using Shewchuk's `triangle library
 <https://www.cs.cmu.edu/~quake/triangle.html>`_.  It is both robust and
 flexible.  We provide a pythonic wrapper over Shewchuk's triangle that exposes
 most of its powers.


### PR DESCRIPTION
As well as this typo... the 

> tetrahedralization in 3D is a much **harder** problem

typo doesn't seem to be pushed to the actual docs?