### PR TITLE
New feature: wire inflation edge connection aspect ratio.

### DIFF
--- a/python/PyWires.cpp
+++ b/python/PyWires.cpp
@@ -165,7 +165,7 @@ void init_Wires(py::module &m) {
         .def("get_face_sources", &InflatorEngine::get_face_sources)
         .def("get_thickness_type", &InflatorEngine::get_thickness_type)
         .def("set_profile", &InflatorEngine::set_profile)
-        .def("set_max_aspect", &InflatorEngine::set_max_aspect);
+        .def("set_aspect_max", &InflatorEngine::set_aspect_max);
 
     py::enum_<InflatorEngine::ThicknessType>(inflator, "ThicknessType")
         .value("PER_VERTEX", InflatorEngine::PER_VERTEX)

--- a/python/PyWires.cpp
+++ b/python/PyWires.cpp
@@ -164,7 +164,8 @@ void init_Wires(py::module &m) {
         .def("get_faces", &InflatorEngine::get_faces)
         .def("get_face_sources", &InflatorEngine::get_face_sources)
         .def("get_thickness_type", &InflatorEngine::get_thickness_type)
-        .def("set_profile", &InflatorEngine::set_profile);
+        .def("set_profile", &InflatorEngine::set_profile)
+        .def("set_max_aspect", &InflatorEngine::set_max_aspect);
 
     py::enum_<InflatorEngine::ThicknessType>(inflator, "ThicknessType")
         .value("PER_VERTEX", InflatorEngine::PER_VERTEX)

--- a/tools/Wires/Inflator/InflatorEngine.h
+++ b/tools/Wires/Inflator/InflatorEngine.h
@@ -62,7 +62,7 @@ class InflatorEngine {
         ThicknessType get_thickness_type() const { return m_thickness_type; }
 
         void set_profile(WireProfilePtr profile) { m_profile = profile; }
-        void set_max_aspect(Float aspect) { m_aspect_max = aspect; }
+        void set_aspect_max(Float aspect) { m_aspect_max = aspect; }
 
     protected:
         void clean_up();

--- a/tools/Wires/Inflator/InflatorEngine.h
+++ b/tools/Wires/Inflator/InflatorEngine.h
@@ -62,6 +62,7 @@ class InflatorEngine {
         ThicknessType get_thickness_type() const { return m_thickness_type; }
 
         void set_profile(WireProfilePtr profile) { m_profile = profile; }
+        void set_max_aspect(Float aspect) { m_aspect_max = aspect; }
 
     protected:
         void clean_up();
@@ -82,6 +83,7 @@ class InflatorEngine {
         VectorF m_thickness;
         ThicknessType m_thickness_type;
         WireProfilePtr m_profile;
+        Float m_aspect_max;
         Subdivision::Ptr m_refiner;
         size_t m_subdiv_order;
         VectorF m_rel_correction;

--- a/tools/Wires/Inflator/SimpleInflator.cpp
+++ b/tools/Wires/Inflator/SimpleInflator.cpp
@@ -90,6 +90,7 @@ void SimpleInflator::initialize() {
     m_face_list.clear();
     m_face_source_list.clear();
     m_num_vertex_accumulated = 0;
+    m_aspect_max = 1.0;
 
     if (!m_wire_network->with_connectivity()) {
         m_wire_network->compute_connectivity();
@@ -203,7 +204,7 @@ void SimpleInflator::connect_end_loops() {
         Float edge_length = edge_lengths(i, 0);
         const auto& end_loops = m_end_loops[i];
         const size_t num_segments = std::max(1.0,
-                std::round(edge_length / ave_thickness));
+                std::round(edge_length / ave_thickness / m_aspect_max));
         MatrixFr pts((num_segments+1)*loop_size, dim);
 
         for (size_t j=0; j<num_segments+1; j++) {


### PR DESCRIPTION
I noticed when connecting vertices that the beams were subdivided such that no section of a beam would be longer than it is wide. This isn't always necessary, and in my case caused output meshes to be much larger than needed. I therefore added a method to specify a maximum aspect ratio for beam segments other than 1. Setting a large allowable aspect ratio can effectively be used to force each beam face to only use 2 triangles, thereby minimizing file size.