### PR TITLE
Remove "import clock"

### DIFF
--- a/python/pymesh/timethis.py
+++ b/python/pymesh/timethis.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from time import clock;
 from time import time;
 import functools
 


### PR DESCRIPTION
It's not used, and it prevents PyMesh from working with Python 3.8.