### PR TITLE
Fix patches abs path for custom $PYMESH_PATH

### DIFF
--- a/docker/patches/patch_wheel.py
+++ b/docker/patches/patch_wheel.py
@@ -40,7 +40,7 @@ def patch_wheel(wheel_file):
             continue
         cmd = "./package_dependencies.py {}".format(
                 os.path.join(lib_dir, lib_file))
-        check_call(cmd.split(), cwd="/root/PyMesh/docker/patches")
+        check_call(cmd.split(), cwd=os.path.dirname(os.path.realpath(__file__)))
 
     cmd = "rm -rf {}".format(os.path.join(extraction_dir, "pymesh/third_party"))
     check_call(cmd.split())


### PR DESCRIPTION
It solves the issue of not being able to patch when the `PYMESH_PATH` is different from the one set in the project Dockerfiles, `/root/PyMesh`.