### PR TITLE
Fix mmg build error for multiple definitions

### DIFF
--- a/docker/py2.7/Dockerfile
+++ b/docker/py2.7/Dockerfile
@@ -3,8 +3,7 @@ WORKDIR /root/
 ARG BRANCH="main"
 ARG NUM_CORES=2
 
-RUN echo "deb http://ftp.us.debian.org/debian unstable main contrib non-free" >> /etc/apt/sources.list.d/unstable.list &&\
-    apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     git \

--- a/docker/py3.5/Dockerfile
+++ b/docker/py3.5/Dockerfile
@@ -3,8 +3,7 @@ WORKDIR /root/
 ARG BRANCH="main"
 ARG NUM_CORES=2
 
-RUN echo "deb http://ftp.us.debian.org/debian unstable main contrib non-free" >> /etc/apt/sources.list.d/unstable.list &&\
-    apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     git \

--- a/docker/py3.6/Dockerfile
+++ b/docker/py3.6/Dockerfile
@@ -3,8 +3,7 @@ WORKDIR /root/
 ARG BRANCH="main"
 ARG NUM_CORES=2
 
-RUN echo "deb http://ftp.us.debian.org/debian unstable main contrib non-free" >> /etc/apt/sources.list.d/unstable.list &&\
-    apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     git \

--- a/docker/py3.7/Dockerfile
+++ b/docker/py3.7/Dockerfile
@@ -3,8 +3,7 @@ WORKDIR /root/
 ARG BRANCH="main"
 ARG NUM_CORES=2
 
-RUN echo "deb http://ftp.us.debian.org/debian unstable main contrib non-free" >> /etc/apt/sources.list.d/unstable.list &&\
-    apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     git \


### PR DESCRIPTION
The error happens during a Docker image build.

**Steps to reproduce**
1. 
```sh
$ docker build docker/py3.7/`
...
[ 22%] Built target libmmg2d_a
Scanning dependencies of target mmg2d
[ 23%] Building C object CMakeFiles/mmg2d.dir/src/mmg2d/mmg2d.c.o
[ 23%] Linking C executable bin/mmg2d_O3
/usr/bin/ld: lib/libmmg2d.a(API_functions.c.o):(.bss+0x0): multiple definition of `MMG5_indPt'; CMakeFiles/mmg2d.dir/src/mmg2d/mmg2d.c.o:(.bss+0xb78): first defined here
/usr/bin/ld: lib/libmmg2d.a(API_functions.c.o):(.bss+0x8): multiple definition of `MMG5_indElt'; CMakeFiles/mmg2d.dir/src/mmg2d/mmg2d.c.o:(.bss+0xb80): first defined here
/usr/bin/ld: lib/libmmg2d.a(API_functions.c.o):(.bss+0x10): multiple definition of `MMG5_compute_meanMetricAtMarkedPoints'; CMakeFiles/mmg2d.dir/src/mmg2d/mmg2d.c.o:(.bss+0xb88): first defined here
...
CMakeFiles/mmg2d.dir/src/mmg2d/mmg2d.c.o:(.bss+0xb98): first defined here
/usr/bin/ld: lib/libmmg2d.a(cenrad_2d.c.o):(.bss+0x60): multiple definition of `MMG5_lenSurfEdg'; CMakeFiles/mmg2d.dir/src/mmg2d/mmg2d.c.o:(.bss+0xba0): first defined here
/usr/bin/ld: lib/libmmg2d.a(cenrad_2d.c.o):(.bss+0x68): multiple definition of `MMG5_bezierCP'; CMakeFiles/mmg2d.dir/src/mmg2d/mmg2d.c.o:(.bss+0xba8): first defined here
/usr/bin/ld: lib/libmmg2d.a(cenrad_2d.c.o):(.bss+0x70): multiple definition of `MMG5_chkmsh'; CMakeFiles/mmg2d.dir/src/mmg2d/mmg2d.c.o:(.bss+0xbb0): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/mmg2d.dir/build.make:105: bin/mmg2d_O3] Error 1
make[1]: *** [CMakeFiles/Makefile2:192: CMakeFiles/mmg2d.dir/all] Error 2
make: *** [Makefile:171: all] Error 2
Traceback (most recent call last):
  File "third_party/build.py", line 82, in <module>
    main();
  File "third_party/build.py", line 79, in main
    build(args.package, args.cleanup);
  File "third_party/build.py", line 75, in build
    build_generic(package, cleanup=cleanup);
  File "third_party/build.py", line 47, in build_generic
    subprocess.check_call(cmd.split());
  File "/usr/local/lib/python3.7/subprocess.py", line 363, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['cmake', '--build', '/root/PyMesh/third_party/../third_party/build/mmg']' returned non-zero exit status 2.
Traceback (most recent call last):
  File "./setup.py", line 200, in <module>
    distclass=BinaryDistribution,
  File "/usr/local/lib/python3.7/site-packages/setuptools/__init__.py", line 153, in setup
    return distutils.core.setup(**attrs)
  File "/usr/local/lib/python3.7/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/local/lib/python3.7/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/usr/local/lib/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/usr/local/lib/python3.7/site-packages/wheel/bdist_wheel.py", line 299, in run
    self.run_command('build')
  File "/usr/local/lib/python3.7/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/usr/local/lib/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "./setup.py", line 102, in run
    self.build_third_party()
  File "./setup.py", line 68, in build_third_party
    check_call(c.split())
  File "/usr/local/lib/python3.7/subprocess.py", line 363, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['third_party/build.py', 'mmg']' returned non-zero exit status 1.
The command '/bin/sh -c git submodule update --init &&     pip install -r $PYMESH_PATH/python/requirements.txt &&     ./setup.py bdist_wheel &&     rm -rf build_3.7 third_party/build &&     python $PYMESH_PATH/docker/patches/patch_wheel.py dist/pymesh2*.whl &&     pip install dist/pymesh2*.whl &&     python -c "import pymesh; pymesh.test()"' returned a non-zero code: 1
```

**Related issues**
https://github.com/PyMesh/PyMesh/issues/255 