### PR TITLE
Use a dictionary-style interface for setting, adding and getting of attributes of the mesh

### DIFF
--- a/python/pymesh/Mesh.py
+++ b/python/pymesh/Mesh.py
@@ -60,6 +60,23 @@ class Mesh(object):
         """
         self.__mesh = raw_mesh
 
+    def __setitem__(self, key, value):
+        """ Set an attribute of the mesh. Creates it if not present.
+        """
+        if not self.has_attribute(key):
+            self.add_attribute(key)
+        self.set_attribute(key, value)
+
+    def __getitem__(self, key):
+        """ Same as get_attribute but using dictionary-style interface
+        """
+        return self.get_attribute(key)
+
+    def __delitem__(self, key):
+        """ Same as remove_attribute but using dictionary-style interface
+        """
+        return self.remove_attribute(key)
+
     def add_attribute(self, name):
         """ Add an attribute to mesh.
         """


### PR DESCRIPTION
This pull request adds a dictionary-style interface to the mesh class.

### Before this PR
```python
mesh = pymesh.form_mesh(...)
mesh.add_attribute("attr1")
mesh.set_attribute("attr1", compute_the_first_attribute(mesh))
attr = mesh.get_attribute('attr1')
```
### After this PR is merged
```python
mesh = py.mesh.form_mesh(...)
mesh['attr1'] = compute_the_first_attribute(mesh)
attr = mesh['attr1']
```

### Question: 
Is it maybe better to return the correct shape of the matrix returned by `__getitem__`? It might be more straightforward to use then for the user. In order to implement this feature it is required to keep track of the attributes being vertex, edge, face, voxel attributes, which is not yet there in the class. What do you think, would that make sense?
Thank you :)