### PR TITLE
Fix compilation error in CMake

### DIFF
--- a/cmake/FindAllDependencies.cmake
+++ b/cmake/FindAllDependencies.cmake
@@ -154,6 +154,7 @@ endif ()
 
 # Nlohmann/json
 if (NOT TARGET nlohmann_json::nlohmann_json)
+    include(GNUInstallDirs)
     find_package(nlohmann_json QUIET REQUIRED
-        HINTS ${PROJECT_SOURCE_DIR}/python/pymesh/third_party/lib/cmake/nlohmann_json)
+        HINTS ${PROJECT_SOURCE_DIR}/python/pymesh/third_party/${CMAKE_INSTALL_LIBDIR}/cmake/nlohmann_json)
 endif()


### PR DESCRIPTION
the `nlohmann_json` package is not found during the compilation. The reason is a problem of the path handcoded in the `CMakeLists.txt`.

The fix consists to use `GNUInstallDirs` as in the `json` module.