### PR TITLE
Fixed undefined Reference to BooleanEngine::get_available_engines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.dia~
 *.dia.autosave
 *.egg-info
+.vscode
 .DS_Store
 
 lib/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ lib/
 bin/
 swig/
 build/
+Build/
 build_*/
 dist/
 python/pymesh/lib

--- a/tools/Boolean/BooleanEngine.cpp
+++ b/tools/Boolean/BooleanEngine.cpp
@@ -103,7 +103,7 @@ bool BooleanEngine::supports(const std::string& engine_name) {
     return false;
 }
 
-std::vector<std::string> get_available_engines() {
+std::vector<std::string> BooleanEngine::get_available_engines() {
     std::vector<std::string> engine_names;
 #if WITH_IGL_AND_CGAL
     engine_names.push_back("igl");


### PR DESCRIPTION
i noticed that whenever i called the BooleanEngine::get_available_engines() function i would get undefined reference during compile.
The function is implemented but it was just not associated with the class.