### PR TITLE
#114 workaround.  remove_duplicated_vertices before remove_degenerated_triangles

### DIFF
--- a/scripts/fix_mesh.py
+++ b/scripts/fix_mesh.py
@@ -23,6 +23,7 @@ def fix_mesh(mesh, detail="normal"):
     print("Target resolution: {} mm".format(target_len))
 
     count = 0
+    mesh, __ = pymesh.remove_duplicated_vertices(mesh)
     mesh, __ = pymesh.remove_degenerated_triangles(mesh, 100)
     mesh, __ = pymesh.split_long_edges(mesh, target_len)
     num_vertices = mesh.num_vertices


### PR DESCRIPTION
In light of Issue #114, it would seem prudent if fix_mesh called remove_duplicated_vertices before remove_degenerated_triangles.

This is the workaround suggested in the issue.  I have seen the reported "RuntimeError: Triangle contains an zero edge, report this bug" error message myself when running fix_mesh, and adding this line allows me to run fix_mesh successfully.